### PR TITLE
Fix build-filemanager.yml file to use right commandline args

### DIFF
--- a/.github/workflows/build-filemanager.yml
+++ b/.github/workflows/build-filemanager.yml
@@ -27,4 +27,4 @@ jobs:
         run: mkdir build && cd build && cmake .. && make && cp *.a ../samples/
 
       - name: cmake-samples
-        run: cd samples && mkdir build && cd build && cmake .. && make && ./main
+        run: cd samples && mkdir build && cd build && cmake .. && make && ./main ../../


### PR DESCRIPTION
Fix CI in favor of #8.